### PR TITLE
Updated mothur tools to use data tables

### DIFF
--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/align.check.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/align.check.xml
@@ -24,9 +24,7 @@
     </param>
     <when value="cached">
      <param name="map" type="select" label="map - Select a secondary structure map" help="Contact Galaxy team for additions">
-      <options from_file="mothur_map.loc">
-       <column name="name" index="0" />
-       <column name="value" index="1" />
+      <options from_data_table="mothur_map">
       </options>
      </param>
     </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/align.seqs.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/align.seqs.xml
@@ -34,9 +34,7 @@
    </param>
    <when value="ref">
     <param name="template" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.ccode.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.ccode.xml
@@ -30,9 +30,7 @@
    </param>
    <when value="ref">
     <param name="template" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.check.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.check.xml
@@ -34,9 +34,7 @@
    </param>
    <when value="ref">
     <param name="template" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.pintail.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.pintail.xml
@@ -44,9 +44,7 @@
    </param>
    <when value="ref">
     <param name="template" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.slayer.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.slayer.xml
@@ -52,9 +52,7 @@
    </param>
    <when value="ref">
     <param name="template" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.uchime.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/chimera.uchime.xml
@@ -91,9 +91,7 @@
    </param>
    <when value="ref">
     <param name="reference" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/classify.otu.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/classify.otu.xml
@@ -42,9 +42,7 @@
    </param>
    <when value="ref">
     <param name="taxonomy" type="select" format="seq.taxonomy" label="taxonomy - Taxonomy Reference">
-     <options from_file="mothur_taxonomy.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_taxonomy">
      </options>
     </param>
    </when>
@@ -61,9 +59,7 @@
    <when value="None"/>
    <when value="ref">
     <param name="taxonomy" type="select" format="seq.taxonomy" label="reftaxonomy - Taxonomy Reference used when sequences were classified">
-     <options from_file="mothur_taxonomy.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_taxonomy">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/classify.seqs.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/classify.seqs.xml
@@ -53,9 +53,7 @@
 			</param>
 			<when value="ref">
 				<param name="template" type="select" label="reference - Select an alignment database " help="">
-					<options from_file="mothur_aligndb.loc">
-						<column name="name" index="0" />
-						<column name="value" index="1" />
+					<options from_data_table="mothur_aligndb">
 					</options>
 				</param>
 			</when>
@@ -70,9 +68,7 @@
 			</param>
 			<when value="ref">
 				<param name="taxonomy" type="select" format="seq.taxonomy" label="taxonomy - Taxonomy reference">
-					<options from_file="mothur_taxonomy.loc">
-						<column name="name" index="0" />
-						<column name="value" index="1" />
+					<options from_data_table="mothur_taxonomy">
 					</options>
 				</param>
 			</when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/seq.error.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/seq.error.xml
@@ -67,9 +67,7 @@
    </param>
    <when value="ref">
     <param name="template" type="select" label="reference - Select an alignment database " help="">
-     <options from_file="mothur_aligndb.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_aligndb">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/shhh.flows.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/shhh.flows.xml
@@ -39,9 +39,7 @@
    <when value="ref">
     <param name="lookup" type="select" format="tabular" label="lookup - intensity value per homopolymer length"
      help="table of the probability of observing an intensity value for a given homopolymer length">
-     <options from_file="mothur_lookup.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_lookup">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/summary.tax.xml
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/summary.tax.xml
@@ -28,9 +28,7 @@
    </param>
    <when value="ref">
     <param name="taxonomy" type="select" format="seq.taxonomy" label="taxonomy - Taxonomy Reference">
-     <options from_file="mothur_taxonomy.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_taxonomy">
      </options>
     </param>
    </when>
@@ -49,9 +47,7 @@
    <when value="none"/>
    <when value="ref">
     <param name="taxonomy" type="select" format="seq.taxonomy" label="reftaxonomy - Taxonomy Reference used when sequences were classified">
-     <options from_file="mothur_taxonomy.loc">
-      <column name="name" index="0" />
-      <column name="value" index="1" />
+     <options from_data_table="mothur_taxonomy">
      </options>
     </param>
    </when>

--- a/wrappers/Mothur_Toolsuite/mothur/tools/mothur/tool_data_table_conf.xml.sample
+++ b/wrappers/Mothur_Toolsuite/mothur/tools/mothur/tool_data_table_conf.xml.sample
@@ -1,0 +1,18 @@
+<tables>
+  <table name="mothur_aligndb" comment_char="#">
+    <columns>name, value</columns>
+    <file path="tool-data/mothur_aligndb.loc" />
+  </table>
+  <table name="mothur_lookup" comment_char="#">
+    <columns>name, value</columns>
+    <file path="tool-data/mothur_lookup.loc" />
+  </table>
+  <table name="mothur_map" comment_char="#">
+    <columns>name, value</columns>
+    <file path="tool-data/mothur_map.loc" />
+  </table>
+  <table name="mothur_taxonomy" comment_char="#">
+    <columns>name, value</columns>
+    <file path="tool-data/mothur_taxonomy.loc" />
+  </table>
+</tables>


### PR DESCRIPTION
Updated XML tool files for a number of Mothur toolsuite tools to use data tables (rather than referencing .loc files directly).

This also requires the new `tool_data_table_conf.xml.sample` file, which defines the data tables.

These changes will allow the reference data in the files to be modified by a data manager.
